### PR TITLE
Refactor speech

### DIFF
--- a/Sources/OpenAI/Intramodular/API/OpenAI.APISpecification.RequestBodies.swift
+++ b/Sources/OpenAI/Intramodular/API/OpenAI.APISpecification.RequestBodies.swift
@@ -385,70 +385,30 @@ extension OpenAI.APISpecification.RequestBodies {
 
 extension OpenAI.APISpecification.RequestBodies {
     public struct CreateSpeech: Codable {
-        
-        /// Encapsulates the voices available for audio generation.
-        ///
-        /// To get aquinted with each of the voices and listen to the samples visit:
-        /// [OpenAI Text-to-Speech – Voice Options](https://platform.openai.com/docs/guides/text-to-speech/voice-options)
-        public enum Voice: String, Codable, CaseIterable {
-            case alloy
-            case echo
-            case fable
-            case onyx
-            case nova
-            case shimmer
-        }
-        
-        public enum ResponseFormat: String, Codable, CaseIterable {
-            case mp3
-            case opus
-            case aac
-            case flac
-        }
-
-        /// The text to generate audio for. The maximum length is 4096 characters.
         public let input: String
-        /// One of the available TTS models: tts-1 or tts-1-hd
-        public let model: OpenAI.Model
-        /// The voice to use when generating the audio. Supported voices are alloy, echo, fable, onyx, nova, and shimmer. Previews of the voices are available in the Text to speech guide.
-        /// https://platform.openai.com/docs/guides/text-to-speech/voice-options
-        public let voice: Voice
-        /// The format to audio in. Supported formats are mp3, opus, aac, and flac.
-        /// Defaults to mp3
-        public let responseFormat: ResponseFormat?
-        /// The speed of the generated audio. Select a value from **0.25** to **4.0**. **1.0** is the default.
-        /// Defaults to 1
-        public let speed: String?
+        public let model: OpenAI.Model.Speech
+        public let voice: String
+        public let responseFormat: String
+        public let speed: String
         
         public enum CodingKeys: String, CodingKey {
-            case model
             case input
+            case model
             case voice
             case responseFormat = "response_format"
             case speed
         }
 
-        public init(model: OpenAI.Model, input: String, voice: Voice, responseFormat: ResponseFormat = .mp3, speed: Double?) {
+        public init(model: OpenAI.Model.Speech, 
+                    input: String,
+                    voice: String,
+                    responseFormat: String,
+                    speed: String) {
             self.model = model
-            self.speed = CreateSpeech.normalizedSpeechSpeed(for: speed)
+            self.speed = speed
             self.input = input
             self.voice = voice
             self.responseFormat = responseFormat
-        }
-        
-        enum Speed: Double {
-            case normal = 1.0
-            case max = 4.0
-            case min = 0.25
-        }
-        
-        static func normalizedSpeechSpeed(for inputSpeed: Double?) -> String {
-            guard let inputSpeed else { return "\(Self.Speed.normal.rawValue)" }
-            let isSpeedOutOfBounds = inputSpeed <= Self.Speed.min.rawValue || Self.Speed.max.rawValue <= inputSpeed
-            guard !isSpeedOutOfBounds else {
-                return inputSpeed < Self.Speed.min.rawValue ? "\(Self.Speed.min.rawValue)" : "\(Self.Speed.max.rawValue)"
-            }
-            return "\(inputSpeed)"
         }
     }
 }

--- a/Sources/OpenAI/Intramodular/Models/OpenAI.SpeechRequest.swift
+++ b/Sources/OpenAI/Intramodular/Models/OpenAI.SpeechRequest.swift
@@ -12,8 +12,8 @@ public struct SpeechRequest {
     public init(input: StringOf4096CharOrLess,
                 model: OpenAI.Model.Speech,
                 voice: Voice = .alloy,
-                responseFormat: ResponseFormat? = nil,
-                speed: ValidatedSpeed? = nil) {
+                responseFormat: ResponseFormat = .defaultFormat,
+                speed: ValidatedSpeed = ValidatedSpeed()) {
         self.input = input
         self.model = model
         self.voice = voice
@@ -54,26 +54,16 @@ public struct SpeechRequest {
         case aac
         /// FLAC: For lossless audio compression, favored by audio enthusiasts for archiving.
         case flac
-    }
-    public let responseFormat: ResponseFormat?
-    private var defaultResponseFormat: ResponseFormat {
-        if let responseFormat = responseFormat {
-            return responseFormat
-        } else {
+        
+        public static var defaultFormat: ResponseFormat {
             return .mp3
         }
     }
+    public let responseFormat: ResponseFormat
     
     /// The speed of the generated audio. Select a value from **0.25** to **4.0**. **1.0** is the default.
     /// Defaults to 1
-    public let speed: ValidatedSpeed?
-    private var defaultSpeed: String {
-        if let speed = speed {
-            return "\(speed)"
-        } else {
-            return "\(ValidatedSpeed.Speed.normal.rawValue)"
-        }
-    }
+    public let speed: ValidatedSpeed
     
     public func request(fromClient client: OpenAI.APIClient) async throws -> OpenAI.Speech? {
         
@@ -81,8 +71,8 @@ public struct SpeechRequest {
             model: model,
             input: input.string,
             voice: voice.rawValue,
-            responseFormat: defaultResponseFormat.rawValue,
-            speed: defaultSpeed)
+            responseFormat: responseFormat.rawValue,
+            speed: "\(speed.speed)")
         
         do {
             let speech = try await client.createSpeech(requestBody: createSpeechRequest)
@@ -145,6 +135,11 @@ extension SpeechRequest {
             case min = 0.25
         }
         
+        // default value
+        public init() {
+            self.value = 1.0
+        }
+        
         public init(speed: Double) throws {
             guard speed >= Speed.min.rawValue && speed <= Speed.max.rawValue else {
                 throw ValidationError.invalidSpeed(speed)
@@ -165,5 +160,6 @@ extension SpeechRequest {
         }
     }
 }
+
 
 

--- a/Sources/OpenAI/Intramodular/Models/OpenAI.SpeechRequest.swift
+++ b/Sources/OpenAI/Intramodular/Models/OpenAI.SpeechRequest.swift
@@ -1,0 +1,169 @@
+//
+//  File.swift
+//  
+//
+//  Created by Natasha Murashev on 4/24/24.
+//
+
+import Foundation
+
+public struct SpeechRequest {
+    
+    public init(input: StringOf4096CharOrLess,
+                model: OpenAI.Model.Speech,
+                voice: Voice,
+                responseFormat: ResponseFormat? = nil,
+                speed: ValidatedSpeed? = nil) {
+        self.input = input
+        self.model = model
+        self.voice = voice
+        self.responseFormat = responseFormat
+        self.speed = speed
+    }
+    
+    /// Encapsulates the voices available for audio generation.
+
+    /// The text to generate audio for. The maximum length is 4096 characters.
+    public let input: StringOf4096CharOrLess
+    
+    /// One of the available TTS models: tts-1 or tts-1-hd
+    public let model: OpenAI.Model.Speech
+    
+    /// To get aquinted with each of the voices and listen to the samples visit:
+    /// [OpenAI Text-to-Speech – Voice Options](https://platform.openai.com/docs/guides/text-to-speech/voice-options)
+    public enum Voice: String, Codable, CaseIterable {
+        case alloy
+        case echo
+        case fable
+        case onyx
+        case nova
+        case shimmer
+    }
+    /// The voice to use when generating the audio. Supported voices are alloy, echo, fable, onyx, nova, and shimmer. Previews of the voices are available in the Text to speech guide.
+    /// https://platform.openai.com/docs/guides/text-to-speech/voice-options
+    public let voice: Voice
+    
+
+    /// The format to audio in. Supported formats are mp3, opus, aac, and flac.
+    /// Defaults to mp3
+    public enum ResponseFormat: String, Codable, CaseIterable {
+        case mp3
+        /// Opus: For internet streaming and communication, low latency.
+        case opus
+        /// AAC: For digital audio compression, preferred by YouTube, Android, iOS.
+        case aac
+        /// FLAC: For lossless audio compression, favored by audio enthusiasts for archiving.
+        case flac
+    }
+    public let responseFormat: ResponseFormat?
+    private var defaultResponseFormat: ResponseFormat {
+        if let responseFormat = responseFormat {
+            return responseFormat
+        } else {
+            return .mp3
+        }
+    }
+    
+    /// The speed of the generated audio. Select a value from **0.25** to **4.0**. **1.0** is the default.
+    /// Defaults to 1
+    public let speed: ValidatedSpeed?
+    private var defaultSpeed: String {
+        if let speed = speed {
+            return "\(speed)"
+        } else {
+            return "\(ValidatedSpeed.Speed.normal.rawValue)"
+        }
+    }
+    
+    public func request(fromClient client: OpenAI.APIClient) async throws -> OpenAI.Speech? {
+        
+        let createSpeechRequest = OpenAI.APISpecification.RequestBodies.CreateSpeech(
+            model: model,
+            input: input.string,
+            voice: voice.rawValue,
+            responseFormat: defaultResponseFormat.rawValue,
+            speed: defaultSpeed)
+        
+        do {
+            let speech = try await client.createSpeech(requestBody: createSpeechRequest)
+            return speech
+        } catch {
+            print(error)
+            return nil
+        }
+    }
+}
+
+extension SpeechRequest {
+    /// A struct to encapsulate a string that is validated to be 4096 characters or less.
+    public struct StringOf4096CharOrLess {
+        private var value: String
+
+        /// The string value, guaranteed to be 4096 characters or less.
+        public var string: String {
+            return value
+        }
+
+        /// Initializes a ValidatedString with a given string.
+        /// Throws an error if the string is more than 4096 characters.
+        ///
+        /// - Parameter string: The string to validate and store.
+        /// - Throws: An error if the string exceeds 4096 characters.
+        init(string: String) throws {
+            guard string.count <= 4096 else {
+                throw ValidationError.stringTooLong(string.count)
+            }
+            self.value = string
+        }
+
+        /// Error types for string validation failures.
+        enum ValidationError: Error, CustomStringConvertible {
+            case stringTooLong(Int)
+
+            var description: String {
+                switch self {
+                case .stringTooLong(let count):
+                    return "String is too long: \(count) characters (max 4096 allowed)."
+                }
+            }
+        }
+    }
+}
+
+extension SpeechRequest {
+    public struct ValidatedSpeed {
+        private var value: Double
+
+        /// The speed value, guaranteed to be between 0.25 and 4.0.
+        public var speed: Double {
+            return value
+        }
+
+        enum Speed: Double {
+            case normal = 1.0
+            case max = 4.0
+            case min = 0.25
+        }
+        
+        public init(speed: Double) throws {
+            guard speed >= Speed.min.rawValue && speed <= Speed.max.rawValue else {
+                throw ValidationError.invalidSpeed(speed)
+            }
+            self.value = speed
+        }
+
+        /// Error types for speed validation failures.
+        enum ValidationError: Error, CustomStringConvertible {
+            case invalidSpeed(Double)
+
+            var description: String {
+                switch self {
+                case .invalidSpeed(let speed):
+                    return "Invalid speed: \(speed). Speed must be between 0.25 and 4.0."
+                }
+            }
+        }
+    }
+}
+
+

--- a/Sources/OpenAI/Intramodular/Models/OpenAI.SpeechRequest.swift
+++ b/Sources/OpenAI/Intramodular/Models/OpenAI.SpeechRequest.swift
@@ -11,7 +11,7 @@ public struct SpeechRequest {
     
     public init(input: StringOf4096CharOrLess,
                 model: OpenAI.Model.Speech,
-                voice: Voice,
+                voice: Voice = .alloy,
                 responseFormat: ResponseFormat? = nil,
                 speed: ValidatedSpeed? = nil) {
         self.input = input

--- a/Sources/OpenAI/Intramodular/OpenAI.APIClient.swift
+++ b/Sources/OpenAI/Intramodular/OpenAI.APIClient.swift
@@ -194,34 +194,7 @@ extension OpenAI.APIClient {
 }
 
 extension OpenAI.APIClient {
-    public func createSpeech(
-        model: OpenAI.Model,
-        text: String,
-        voice: OpenAI.APISpecification.RequestBodies.CreateSpeech.Voice = .alloy,
-        speed: Double?
-    ) async throws -> OpenAI.Speech {
-        let requestBody = OpenAI.APISpecification.RequestBodies.CreateSpeech(
-            model: model,
-            input: text,
-            voice: voice,
-            speed: speed
-        )
-        let data = try await run(\.createSpeech, with: requestBody)
-        return OpenAI.Speech(data: data)
-    }
-    
-    public func createSpeech(
-        model: OpenAI.Model.Speech,
-        text: String,
-        voice: OpenAI.APISpecification.RequestBodies.CreateSpeech.Voice = .alloy,
-        speed: Double?
-    ) async throws -> OpenAI.Speech {
-        let requestBody = OpenAI.APISpecification.RequestBodies.CreateSpeech(
-            model: OpenAI.Model.speech(model),
-            input: text,
-            voice: voice,
-            speed: speed
-        )
+    public func createSpeech(requestBody: OpenAI.APISpecification.RequestBodies.CreateSpeech) async throws -> OpenAI.Speech {
         let data = try await run(\.createSpeech, with: requestBody)
         return OpenAI.Speech(data: data)
     }


### PR DESCRIPTION
This is an example of how to refactor the API to create a layer between the developer with validation logic and simple parameters sent to OpenAI that would be very simple to use, document, and test. 

to use: 
```swift
func getSpeech(myOpenAIClient: OpenAI.APIClient) async {
    do {
        // ensures the developer is aware of the API limitations and validates the data
        let myValidatedInput = try SpeechRequest.StringOf4096CharOrLess(string: "Hello, World")
        let myValidatedSpeed = try SpeechRequest.ValidatedSpeed(speed: 1.5)
        
        let speechRequest = SpeechRequest(input: myValidatedInput, model: .tts_1, speed: myValidatedSpeed)
        let speech = try await speechRequest.request(fromClient: myOpenAIClient)
        
    } catch {
        print(error)
    }
}
```