### PR TITLE
add ElevenLabs models as enums

### DIFF
--- a/Sources/ElevenLabs/Intramodular/ElevenLabs.APISpecification.swift
+++ b/Sources/ElevenLabs/Intramodular/ElevenLabs.APISpecification.swift
@@ -24,12 +24,12 @@ extension ElevenLabs.APISpecification {
             
             public let text: String
             public let voiceSettings: [String: JSON]
-            public let model: String?
+            public let model: ElevenLabs.Model
             
             public init(
                 text: String,
                 voiceSettings: [String: JSON],
-                model: String?
+                model: ElevenLabs.Model
             ) {
                 self.text = text
                 self.voiceSettings = voiceSettings
@@ -71,5 +71,17 @@ extension ElevenLabs {
             self.voiceID = voiceID
             self.name = name
         }
+    }
+    
+    public enum Model: String, Codable, Sendable {
+        // Information about each model here: https://help.elevenlabs.io/hc/en-us/articles/17883183930129-What-models-do-you-offer-and-what-is-the-difference-between-them
+        // Using cutting-edge technology, this is a highly optimized model for real-time applications that require very low latency, but it still retains the fantastic quality offered in our other models. Even if optimized for real-time and more conversational applications, we still recommend testing it out for other applications as it is very versatile and stable.
+        case TurboV2 = "eleven_turbo_v2"
+        /// This model is a powerhouse, excelling in stability, language diversity, and accuracy in replicating accents and voices. Its speed and agility are remarkable considering its size. Multilingual v2 supports a 28 languages.
+        case MultilingualV2 = "eleven_multilingual_v2"
+        /// This model was created specifically for English and is the smallest and fastest model we offer. As our oldest model, it has undergone extensive optimization to ensure reliable performance but it is also the most limited and generally the least accurate.
+        case EnglishV1 = "eleven_monolingual_v1"
+        /// Taking a step towards global access and usage, we introduced Multilingual v1 as our second offering. Has been an experimental model ever since release. To this day, it still remains in the experimental phase.
+        case MultilingualV1 = "eleven_multilingual_v1"
     }
 }

--- a/Sources/ElevenLabs/Intramodular/ElevenLabs.swift
+++ b/Sources/ElevenLabs/Intramodular/ElevenLabs.swift
@@ -53,7 +53,7 @@ extension ElevenLabs {
         for text: String,
         voiceID: String,
         voiceSettings: [String: JSON]? = nil,
-        model: String? = nil
+        model: ElevenLabs.Model
     ) async throws -> Data {
         let request = try HTTPRequest(url: URL(string: "\(apiSpecification.host)/v1/text-to-speech/\(voiceID)")!)
             .method(.post)


### PR DESCRIPTION
The ElevenLabs models are widely different (e.g. English vs Multilanguage), so the developer should have to choose which model to use. It is also very confusing to find the actual model ids on their website, so it's confusing which string the model should be, even if the developer does choose a model. 